### PR TITLE
Added textfield on services backend page for svg integration

### DIFF
--- a/lit/app/Config/Form/Pages/ServicesConfig.php
+++ b/lit/app/Config/Form/Pages/ServicesConfig.php
@@ -76,10 +76,10 @@ class ServicesConfig extends FormConfig
                             ->translatable()
                             ->width(12);
 
-                        $form->image('illustration')
-                            ->title('Illustration')
-                            ->maxFiles(1)
-                            ->showFullImage()
+                        $form->textarea('illustration_svg')
+                            ->title('Illustration als SVGS')
+                            ->placeholder('<svg ...')
+                            ->hint('Füge hier den SVG Code ein.')
                             ->width(12);
 
                         $form->wysiwyg('list_primary')
@@ -129,10 +129,10 @@ class ServicesConfig extends FormConfig
                             ->translatable()
                             ->width(12);
 
-                        $form->image('illustration')
-                            ->title('Illustration')
-                            ->maxFiles(1)
-                            ->showFullImage()
+                        $form->textarea('illustration_svg')
+                            ->title('Illustration als SVGS')
+                            ->placeholder('<svg ...')
+                            ->hint('Füge hier den SVG Code ein.')
                             ->width(12);
 
                         $form->wysiwyg('text')

--- a/resources/views/pages/services.blade.php
+++ b/resources/views/pages/services.blade.php
@@ -59,10 +59,9 @@ aw-first-section-is-white
                 <h3 class="h3">
                     {{ $service->h3 }}
                 </h3>
-                <div class="flex items-center object-contain h-40">
-                    @isset($service->illustration)
-                        <x-lit-image class="object-contain h-24 mb-8" :image="$service->illustration" />
-                    {{-- <img src="{{ $service->illustration->url }}" class="mb-8" alt="Illustration: {{ $service->h3 }}"> --}}
+                <div class="flex object-contain h-32">
+                    @isset($service->illustration_svg)
+                        {!! $service->illustration_svg !!}
                     @endisset
                 </div>
 
@@ -150,10 +149,9 @@ aw-first-section-is-white
             @foreach ($services->methods as $method)
             <div class="pr-12 mb-8">
 
-                <div class="flex items-end h-16">
-                    @isset($method->illustration)
-                    {{-- <img src="{{ $method->illustration->url }}" class="mb-8" alt="Illustration: {{ $method->h3 }}"> --}}
-                    <x-lit-image class="object-contain h-16 mb-8" :image="$method->illustration" />
+                <div class="flex items-end object-contain h-16 mb-2">
+                    @isset($method->illustration_svg)
+                        {!! $method->illustration_svg !!}
                     @endisset
                 </div>
 


### PR DESCRIPTION
The SVGs can now be integrated directly by copy and pasting. Might be a good practise to minify the svgs via [SVGOMG](https://jakearchibald.github.io/svgomg/) before pasting them in.